### PR TITLE
Update test_dpa.py: Adding fixture decorator for oadp_ocp_client

### DIFF
--- a/tests/test_dpa.py
+++ b/tests/test_dpa.py
@@ -4,10 +4,7 @@ from openshift.dynamic import DynamicClient
 from openshift_resources.data_protection_application import DataProtectionApplication
 
 
-class DynamicClient:
-    pass
-
-
+@pytest.fixture(scope="module")
 def oadp_ocp_client():
     yield  DynamicClient(client=kubernetes.config.new_client_from_config())
 


### PR DESCRIPTION
The search path for the k8 config file is as usual (KUBECONFIG/etc)
This client can be passed when creating the ODAP & Velero CRs,
In some openshift-wrapper methods, this is actually mandatory  